### PR TITLE
Fixed server settings os for windows

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -222,7 +222,7 @@ error_reporting(0);
 			<td>
 				<select name="host_os">
 					<option value="mac">Mac OS</option>
-					<option value="win">Windows</option>
+					<option value="windows">Windows</option>
 					<option value="linux">Linux</option>
 				</select>
 			</td>


### PR DESCRIPTION
The install page set windows os as "win" instead of "windows" in the database, causing `get_path($name,"blend",$server_os);` to fail because the table for projects uses `blend_windows`, not `blend_win` which affected the server blend path test.
